### PR TITLE
Added  BCM94360NG to the list

### DIFF
--- a/unsupported.md
+++ b/unsupported.md
@@ -3,6 +3,7 @@ With macOS there's a limited amount of supported hardware regardless of which ca
 ## Supported chipsets
 
 * BCM94360CD
+* BCM94360NG
 * BCM94331CD(May require you to force load kext when running Catalina)
 * BCM94360CS2
 * BCM94352Z


### PR DESCRIPTION
Amazing job with the guides buddy.
Just wanted to mention that BCM94360NG is supported natively and works OOB without any extra config on macOS Catalina. Apple watch login works perfectly too.
We should add it to the list.