### PR TITLE
Correct ZAE cards to BT 4.1

### DIFF
--- a/types-of-wireless-card/m2.md
+++ b/types-of-wireless-card/m2.md
@@ -32,9 +32,9 @@ Asus and Lenovo users should also see the [Bluetooth](/misc/bluetooth.md) sectio
   * Lenovo Lite-On WCBN802B(04X6020)(E Key)(BT 4.0)
   * AzureWave AW-CB162NF(A+E Key)(BT 4.0)
 * **BCM94350ZAE**:
-  * Lenovo Foxconn T77H649(A+E Key)(BT 4.0)
-  * Lite-On WCBN808B(A+E Key)(BT 4.0)
-  * Dell DW1820A (A+E Key)(BT 4.0)
+  * Lenovo Foxconn T77H649(A+E Key)(BT 4.1)
+  * Lite-On WCBN808B(A+E Key)(BT 4.1)
+  * Dell DW1820A (A+E Key)(BT 4.1)
 
 Note: The BCM94350ZAE chipset doesn't support power management correctly in macOS so needs to be disabled via property injection. This is **not** guaranteed to fix support on laptops, **do not buy just for a laptop**:
 


### PR DESCRIPTION
Just a minor correction, ZAE cards are BT 4.1.