### PR TITLE
"Fenvi AC1200" is not an M.2 card

### DIFF
--- a/types-of-wireless-card/m2.md
+++ b/types-of-wireless-card/m2.md
@@ -27,7 +27,7 @@ Asus and Lenovo users should also see the [Bluetooth](/misc/bluetooth.md) sectio
 * **BCM943602**:
   * Dell DW1830 (A+E Key, quite wide so make sure your laptop has room) (BT 4.1)
 * **BCM94352Z**:
-  * Fenvi AC1200 (A+E Key, natively supported as based off of a genuine Apple AirPort card) (BT 4.0)
+  * Fenvi BCM94352z (A+E Key, natively supported as based off of a genuine Apple AirPort card) (BT 4.0)
   * Dell DW1560 (A+E Key) (BT 4.0)
   * Lenovo Lite-On WCBN802B (04X6020) (E Key) (BT 4.0)
   * AzureWave AW-CB162NF (A+E Key) (BT 4.0)


### PR DESCRIPTION
see [https://github.com/dortania/bugtracker/issues/305](https://github.com/dortania/bugtracker/issues/305)