### PR TITLE
Update unsupported.md

### DIFF
--- a/unsupported.md
+++ b/unsupported.md
@@ -22,6 +22,7 @@ With macOS, there's a limited amount of supported hardware regardless of which c
 
 * BCM94322
 * All those mentioned in Catalina and newer are also supported in Mojave
+* Mojave and up dropped support for all Atheros cards natively. Support for them can be restored with kexts listed on the next page.
 
 ### High Sierra (10.13) and older
 


### PR DESCRIPTION
Add a note that Atheros cards will need a kext in Mojave and newer as to not confuse users that Atheros is still (somewhat) supported after 10.13