### PR TITLE
Native broadcom support dropped for sonoma

### DIFF
--- a/unsupported.md
+++ b/unsupported.md
@@ -3,12 +3,11 @@
 With macOS, there's a limited amount of supported hardware regardless of which category, and wireless cards are no different.
 
 ## Supported chipsets
-### Sonoma 14 and older
-Sonoma has dropped support for the natively supported Broadcom WiFi/BT cards listed below, they will not work unless you patch the kexts using OCLP.  
-For Intel-based cards, Use ltwm + heliport.
+### Sonoma (14) and Sequoia (15)
+Sonoma and later has officialy dropped support for all the natively supported Broadcom WiFi/BT cards listed, they will not work unless you patch the kexts using OCLP.  
+For Intel-based cards, Use ltwm + heliport, It still works.
 
 ### Big Sur (11), Monterey (12) and Ventura (13)
-
 * BCM943602
 * BCM94360
 * BCM94352

--- a/unsupported.md
+++ b/unsupported.md
@@ -3,8 +3,11 @@
 With macOS, there's a limited amount of supported hardware regardless of which category, and wireless cards are no different.
 
 ## Supported chipsets
+### Sonoma 14 and older
+Sonoma has dropped support for the natively supported Broadcom WiFi/BT cards listed below, they will not work unless you patch the kexts using OCLP.  
+For Intel-based cards, Use ltwm + heliport.
 
-### Big Sur (11) and Monterey (12) and older
+### Big Sur (11), Monterey (12) and Ventura (13)
 
 * BCM943602
 * BCM94360


### PR DESCRIPTION
macOS Sonoma has dropped support for legacy Broadcom WiFi chipsets such as BCM4360, BCM4350, and BCM43602, which were supported in Ventura and earlier versions.

The changes clarifies user confusion regarding Sonoma’s compatibility with Broadcom-based devices and to guide affected users towards workarounds such as (OCLP). 

**References:**
    [Get Broadcom wifi support back on Sonoma](https://github.com/perez987/Broadcom-wifi-back-on-macOS-Sonoma-with-OCLP)
[Broadcom WiFi is dead](https://www.reddit.com/r/hackintosh/comments/141wnjk/state_of_macos_14_sonoma_on_x86/)
