### PR TITLE
Update Kext.md (AirportBrcmFixup note)

### DIFF
--- a/Kext.md
+++ b/Kext.md
@@ -10,7 +10,9 @@
 
 This is needed to fix wifi on many Broadcom cards, while not all of them need them it's generally required when using non-apple manufactured wireless cards. This also has the added functionality of injecting old Broadcom kexts into newer versions of macOS.
 
-* Note: Apple AirPort and Fenvi cards do not need this kext
+Note:
+* You must disable the AirPortBrcm4360 injector plugin with macOS 11+ (see README.md)
+* Apple AirPort and Fenvi cards do not need this kext
 
 ### [BrcmPatchRAM](https://github.com/acidanthera/BrcmPatchRAM/releases)
 


### PR DESCRIPTION
AirPortBrcm4360 injector must not be used with macOS 11+, as it will prevent the original kext from loading